### PR TITLE
Pinsout

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -77,7 +77,6 @@ function openAllMarkerInfoWindow(data) {
                }
         });
     });
-
 }
 
 function sortByBuildingName(data) {
@@ -252,7 +251,7 @@ function repopulate_filters() {
 }
 
 function run_custom_search() {
-     
+    
     // if searching, reset that spot count
     window.update_count = true;
 
@@ -522,7 +521,6 @@ function load_map(latitude, longitude, zoom) {
         window.spacescout_map.setCenter(new google.maps.LatLng(latitude, longitude));
     }
 
-
     google.maps.event.addListener(window.spacescout_map, 'idle', reload_on_idle);
     //next three lines courtesy of samolds
     google.maps.event.addListener(spacescout_map, 'mouseup', function(c) {
@@ -542,6 +540,10 @@ function load_map(latitude, longitude, zoom) {
 
     google.maps.event.addListenerOnce(spacescout_map, 'tilesloaded', function() {
         document.getElementById('center_all').style.display = "inline";
+    });
+
+    google.maps.event.addListener(spacescout_map, 'click', function() {
+        fetch_data();
     });
 
     // append the centering buttons after map has loaded


### PR DESCRIPTION
For SPOT-399. Clicking on a pin "filters" the list, so clicking on the map off the pin now unselects the pin and lists all available spots within the user's filters/location before the pin selection.
