### PR TITLE
Restructured formatting for error messages on suggest and contact forms....

### DIFF
--- a/forms/contact.py
+++ b/forms/contact.py
@@ -16,12 +16,12 @@ from django import forms
 
 
 class ContactForm(forms.Form):
-        name = forms.CharField(max_length=25, label="Your Name")
+        name = forms.CharField(max_length=25, label="Your Name", error_messages={'required':'Required field'})
         sender = forms.EmailField(max_length=40, label="Your Email (Optional)", required=False)
         #feedback_choice = forms.ChoiceField((
             #('', 'Please Select One'),
             #('feedback', 'Leave Feedback'),
             #('problem', 'Report a Problem'),
             #('feature request', 'Request a Feature')), label="Feedback Choice")
-        message = forms.CharField(widget=forms.Textarea(), label="Your Message")
+        message = forms.CharField(widget=forms.Textarea(), label="Your Message", error_messages={'required':'Required field'})
         email_confirmation = forms.CharField(required=False)

--- a/forms/suggest.py
+++ b/forms/suggest.py
@@ -16,12 +16,12 @@ from django import forms
 
 
 class SuggestForm(forms.Form):
-        name = forms.CharField(max_length=25, label="Your Name", required=True)
-        netid = forms.CharField(max_length=25, label="Your UW NetID", required=True)
-        sender = forms.EmailField(max_length=40, label="Your Email", required=True)
-        building = forms.CharField(widget=forms.TextInput(), label="Building Name", required=True)
-        floor = forms.CharField(widget=forms.TextInput(), label="Floor Number", required=True)
+        name = forms.CharField(max_length=25, label="Your Name", required=True, error_messages={'required': 'Required field'})
+        netid = forms.CharField(max_length=25, label="Your UW NetID", required=True, error_messages={'required': 'Required field'})
+        sender = forms.EmailField(max_length=40, label="Your Email", required=True, error_messages={'required': 'Required field'})
+        building = forms.CharField(widget=forms.TextInput(), label="Building Name", required=True, error_messages={'required': 'Required field'})
+        floor = forms.CharField(widget=forms.TextInput(), label="Floor Number", required=True, error_messages={'required': 'Required field'})
         room_number = forms.CharField(widget=forms.TextInput(), label="Room Number (optional)", required=False)
-        description = forms.CharField(widget=forms.Textarea(), label="Description of Space", required=True)
+        description = forms.CharField(widget=forms.Textarea(), label="Description of Space", required=True, error_messages={'required': 'Required field'})
         justification = forms.CharField(widget=forms.Textarea(), label="Why do you recommend this space? (optional)", required=False)
         email_confirmation = forms.CharField(required=False)

--- a/static/css/mobile.less
+++ b/static/css/mobile.less
@@ -435,9 +435,10 @@ button {
 
 .contact-header, .suggest-header { font-size: 20px; margin: 5px 0;  color: @purple_text; width:85%; line-height: 20px; font-weight: normal; }
 
-.fieldWrapper {margin-bottom:10px; font-size: 12px;
+.fieldWrapper { float: left; clear: left; margin-bottom:10px; font-size: 12px;
     label { color: gray; }
     .alert {color: red;}
+    .alerterror { float: right; color: red; font-size: 10px; font-style: italic; }
  }
 
  /* Callout for iOS 5/6 mobile devices */

--- a/templates/contact-form.html
+++ b/templates/contact-form.html
@@ -17,13 +17,19 @@
                 </div>
             {% else %}
                 <div class="fieldWrapper">
-                    {{ field.label_tag }}{{ field }}
+                    {% if field.field.required %}
+                    <label for="id_{{field.name}}">{{field.label}} <span     class="required">*</span>
                     {% for error in field.errors %}
-                        <strong class="alert">{{ error|escape }}</strong>
+                    <span class="alerterror">{{ error|escape }}</span>
                     {% endfor %}
-                </div>
+                        </label>
+                    {% else %}
+                        {{ field.label_tag }}
+                    {% endif %}
+                    {{ field }}
+               </div>
             {% endif %}
         {% endfor %}
-        <input type="submit" value="Send" />
+        <div class="fieldWrapper"><input type="submit" value="Send" /></div>
     </form>
 {% endblock %}

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -35,7 +35,7 @@
     </div>
     {% endif %}
 
-    <div {% if is_mobile %}style="margin:10px; background:#fff;" {% else %}id="main_content" style="padding: 80px;"{% endif %} role="main" aria-labelledby="contact_header">
+    <div {% if is_mobile %}style="padding:10px; background:#fff; overflow: hidden;" {% else %}id="main_content" style="padding: 80px; overflow: hidden;"{% endif %} role="main" aria-labelledby="contact_header">
         {% block contact-content %}{% endblock %}
     </div>
 {% endblock %}

--- a/templates/suggest-form.html
+++ b/templates/suggest-form.html
@@ -18,18 +18,19 @@
             {% else %}
                 <div class="fieldWrapper">
                     {% if field.field.required %}
-                       <label for="id_{{field.name}}">{{field.label}} <span class="required">*</span></label>
+                       <label for="id_{{field.name}}">{{field.label}} <span class="required">*</span>
+                    {% for error in field.errors %}
+                        <span class="alerterror">{{ error|escape }}</span>
+                    {% endfor %}
+                    </label>
                     {% else %}
                         {{ field.label_tag }}
                     {% endif %}
                     {{ field }}
-                    {% for error in field.errors %}
-                        <strong class="alert">{{ error|escape }}</strong>
-                    {% endfor %}
                 </div>
             {% endif %}
         {% endfor %}
-        <input type="submit" value="Send" />
+        <div class="fieldWrapper"><input type="submit" value="Send" /></div>
     </form>
-    <span class="requiredtext">*Required</span>
+    <div class="fieldWrapper"><span class="requiredtext">*Required</span></div>
 {% endblock %}

--- a/templates/suggest.html
+++ b/templates/suggest.html
@@ -25,7 +25,7 @@
     </div>
     {% endif %}
 
-    <div {% if is_mobile %}style="margin:10px; background:#fff;" {% else %}id="main_content" style="padding: 80px;"{% endif %} role="main" aria-labelledby="suggest_header">
+    <div {% if is_mobile %}style="padding:10px; background:#fff; overflow: hidden;" {% else %}id="main_content" style="padding: 80px; overflow: hidden;"{% endif %} role="main" aria-labelledby="suggest_header">
         {% block suggest-content %}{% endblock %}
     </div>
 {% endblock %}


### PR DESCRIPTION
... SPOT-1579. Made changes to css stylings to accommodate the formatting and to make it more flexible to customization in the future. I've checked on both mobile and web for suggest/report a problem pages and common pages to make sure nothing else is out of whack, but let me know if any other pages are using the css for these (such as fieldWrapper).
