### PR TITLE
Remove PermissionsLogging from setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,5 @@ setup(name='SpaceScout-Web',
                         'simplejson',
                         'python-ldap',
                         'mock<=1.0.1',
-                        'PermissionsLogging',
                        ],
      )


### PR DESCRIPTION
The app doesn't rely on it, and we install it at deploy time via another
method.